### PR TITLE
Add a helpful hint for users of Data.Compact

### DIFF
--- a/Data/Vector/Mutable.hs
+++ b/Data/Vector/Mutable.hs
@@ -185,7 +185,10 @@ loopM !n k = let
   in go 0
 
 uninitialised :: a
-uninitialised = error "Data.Vector.Mutable: uninitialised element"
+uninitialised = error $
+  "Data.Vector.Mutable: uninitialised element. " ++
+  "If you run into this using Data.Compact, this is a known problem with Vectors constructed using fromList. " ++
+  "Please use fromListN instead."
 
 -- Length information
 -- ------------------


### PR DESCRIPTION
Compaction traverses the whole of a data structure, including in the case of a Vector, the extra bottoms that might be hidden in the unused elements at the end of an oversized array that was allocated by `fromList`. To help people who trip over this gotcha, let's add a hint to the error message.